### PR TITLE
Add sample SQLite database with seed data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+bin/
+data/*.db
+*.jar

--- a/README.md
+++ b/README.md
@@ -1,5 +1,37 @@
 # IshitasIA
 
+This repository contains a Java Swing application backed by an SQLite database for managing a school nurse's office. On first run the program creates `data/clinic.db` and seeds it with sample records so the interface can be explored with realistic data. The current implementation provides:
+
+- Role-based login for nurse and teachers.
+- Nurse dashboard with search to view student profiles.
+- Teacher form to send digital nurse slips.
+
+The original Criterion A planning document follows below for reference.
+
+## Building
+
+1. Download the SQLite JDBC driver:
+
+   ```sh
+   curl -L -o sqlite-jdbc.jar https://repo1.maven.org/maven2/org/xerial/sqlite-jdbc/3.44.1.0/sqlite-jdbc-3.44.1.0.jar
+   ```
+
+2. Compile the application:
+
+   ```sh
+   javac -cp sqlite-jdbc.jar -d bin $(find src -name '*.java')
+   ```
+
+3. Run the GUI (requires a graphical environment):
+
+   ```sh
+   java -cp bin:sqlite-jdbc.jar Main
+   ```
+
+The application stores information in `data/clinic.db`. If the file is removed, it will be recreated with the same sample records on next launch.
+
+# IshitasIA
+
 Criterion A: Planning
 
 Scenario:

--- a/src/Main.java
+++ b/src/Main.java
@@ -1,0 +1,11 @@
+import ui.LoginFrame;
+
+import javax.swing.*;
+
+public class Main {
+    public static void main(String[] args) {
+        SwingUtilities.invokeLater(() -> {
+            new LoginFrame().setVisible(true);
+        });
+    }
+}

--- a/src/db/AuthService.java
+++ b/src/db/AuthService.java
@@ -1,0 +1,22 @@
+package db;
+
+import model.User;
+import java.sql.*;
+
+public class AuthService {
+    public static User authenticate(String username, String password) {
+        try {
+            Connection conn = Database.getConnection();
+            PreparedStatement ps = conn.prepareStatement("SELECT id, username, role FROM users WHERE username=? AND password=?");
+            ps.setString(1, username);
+            ps.setString(2, password);
+            ResultSet rs = ps.executeQuery();
+            if (rs.next()) {
+                return new User(rs.getInt("id"), rs.getString("username"), rs.getString("role"));
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+}

--- a/src/db/Database.java
+++ b/src/db/Database.java
@@ -1,0 +1,144 @@
+package db;
+
+import java.io.File;
+import java.sql.*;
+
+public class Database {
+    private static final String DB_URL = "jdbc:sqlite:data/clinic.db";
+    private static Connection conn;
+
+    public static Connection getConnection() throws SQLException {
+        if (conn == null || conn.isClosed()) {
+            new File("data").mkdirs();
+            conn = DriverManager.getConnection(DB_URL);
+            initialize();
+        }
+        return conn;
+    }
+
+    private static void initialize() throws SQLException {
+        Statement stmt = conn.createStatement();
+        // users table
+        stmt.executeUpdate("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password TEXT, role TEXT)");
+        // students table
+        stmt.executeUpdate("CREATE TABLE IF NOT EXISTS students (id INTEGER PRIMARY KEY, name TEXT, class TEXT, photo TEXT, conditions TEXT, allergies TEXT, emergency_contact TEXT)");
+        // slips table
+        stmt.executeUpdate("CREATE TABLE IF NOT EXISTS slips (id INTEGER PRIMARY KEY AUTOINCREMENT, student_id INTEGER, teacher_name TEXT, complaint TEXT, time_sent TEXT, nurse_notes TEXT, status TEXT)");
+        // inventory table
+        stmt.executeUpdate("CREATE TABLE IF NOT EXISTS inventory (id INTEGER PRIMARY KEY AUTOINCREMENT, item TEXT UNIQUE, quantity INTEGER, threshold INTEGER)");
+        // medications table
+        stmt.executeUpdate("CREATE TABLE IF NOT EXISTS medications (id INTEGER PRIMARY KEY AUTOINCREMENT, student_id INTEGER, medicine TEXT, dosage TEXT, time_given TEXT)");
+        // insert default users if none exist
+        ResultSet rs = stmt.executeQuery("SELECT COUNT(*) AS count FROM users");
+        if (rs.next() && rs.getInt("count") == 0) {
+            PreparedStatement ps = conn.prepareStatement("INSERT INTO users(username,password,role) VALUES(?,?,?)");
+            ps.setString(1, "nurse");
+            ps.setString(2, "nurse123");
+            ps.setString(3, "nurse");
+            ps.executeUpdate();
+            ps.setString(1, "teacher");
+            ps.setString(2, "teacher123");
+            ps.setString(3, "teacher");
+            ps.executeUpdate();
+            ps.close();
+        }
+        rs.close();
+
+        // sample student records
+        ResultSet rsStudents = stmt.executeQuery("SELECT COUNT(*) AS count FROM students");
+        if (rsStudents.next() && rsStudents.getInt("count") == 0) {
+            PreparedStatement ps = conn.prepareStatement(
+                "INSERT INTO students(id,name,class,photo,conditions,allergies,emergency_contact) VALUES(?,?,?,?,?,?,?)");
+            ps.setInt(1, 1);
+            ps.setString(2, "Alice Johnson");
+            ps.setString(3, "5A");
+            ps.setString(4, "");
+            ps.setString(5, "Asthma");
+            ps.setString(6, "Peanuts");
+            ps.setString(7, "Mrs. Johnson 1234567890");
+            ps.executeUpdate();
+            ps.setInt(1, 2);
+            ps.setString(2, "Bob Smith");
+            ps.setString(3, "6B");
+            ps.setString(4, "");
+            ps.setString(5, "None");
+            ps.setString(6, "N/A");
+            ps.setString(7, "Mr. Smith 0987654321");
+            ps.executeUpdate();
+            ps.setInt(1, 3);
+            ps.setString(2, "Charlie Brown");
+            ps.setString(3, "5A");
+            ps.setString(4, "");
+            ps.setString(5, "Diabetes");
+            ps.setString(6, "Nuts");
+            ps.setString(7, "Mrs. Brown 1122334455");
+            ps.executeUpdate();
+            ps.close();
+        }
+        rsStudents.close();
+
+        // sample inventory records
+        ResultSet rsInv = stmt.executeQuery("SELECT COUNT(*) AS count FROM inventory");
+        if (rsInv.next() && rsInv.getInt("count") == 0) {
+            PreparedStatement ps = conn.prepareStatement("INSERT INTO inventory(item,quantity,threshold) VALUES(?,?,?)");
+            ps.setString(1, "Bandage");
+            ps.setInt(2, 20);
+            ps.setInt(3, 5);
+            ps.executeUpdate();
+            ps.setString(1, "Paracetamol");
+            ps.setInt(2, 30);
+            ps.setInt(3, 10);
+            ps.executeUpdate();
+            ps.setString(1, "Antiseptic");
+            ps.setInt(2, 15);
+            ps.setInt(3, 3);
+            ps.executeUpdate();
+            ps.close();
+        }
+        rsInv.close();
+
+        // sample slips
+        ResultSet rsSlips = stmt.executeQuery("SELECT COUNT(*) AS count FROM slips");
+        if (rsSlips.next() && rsSlips.getInt("count") == 0) {
+            PreparedStatement ps = conn.prepareStatement(
+                "INSERT INTO slips(student_id, teacher_name, complaint, time_sent, nurse_notes, status) VALUES(?,?,?,?,?,?)");
+            ps.setInt(1, 1);
+            ps.setString(2, "Mr. Adams");
+            ps.setString(3, "Headache");
+            ps.setString(4, "2024-05-01 09:15");
+            ps.setString(5, "Given rest");
+            ps.setString(6, "resolved");
+            ps.executeUpdate();
+            ps.setInt(1, 2);
+            ps.setString(2, "Ms. Blake");
+            ps.setString(3, "Stomachache");
+            ps.setString(4, "2024-05-02 10:30");
+            ps.setString(5, "");
+            ps.setString(6, "pending");
+            ps.executeUpdate();
+            ps.close();
+        }
+        rsSlips.close();
+
+        // sample medication history
+        ResultSet rsMed = stmt.executeQuery("SELECT COUNT(*) AS count FROM medications");
+        if (rsMed.next() && rsMed.getInt("count") == 0) {
+            PreparedStatement ps = conn.prepareStatement(
+                "INSERT INTO medications(student_id, medicine, dosage, time_given) VALUES(?,?,?,?)");
+            ps.setInt(1, 1);
+            ps.setString(2, "Paracetamol");
+            ps.setString(3, "10ml");
+            ps.setString(4, "2024-04-20 09:00");
+            ps.executeUpdate();
+            ps.setInt(1, 3);
+            ps.setString(2, "Insulin");
+            ps.setString(3, "5 units");
+            ps.setString(4, "2024-04-21 12:00");
+            ps.executeUpdate();
+            ps.close();
+        }
+        rsMed.close();
+
+        stmt.close();
+    }
+}

--- a/src/db/InventoryDAO.java
+++ b/src/db/InventoryDAO.java
@@ -1,0 +1,68 @@
+package db;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class InventoryDAO {
+    public static class Item {
+        private int id;
+        private String name;
+        private int quantity;
+        private int threshold;
+        public Item(int id, String name, int quantity, int threshold) {
+            this.id = id;
+            this.name = name;
+            this.quantity = quantity;
+            this.threshold = threshold;
+        }
+        public int getId() { return id; }
+        public String getName() { return name; }
+        public int getQuantity() { return quantity; }
+        public int getThreshold() { return threshold; }
+    }
+
+    public static List<Item> getAll() {
+        List<Item> list = new ArrayList<>();
+        try {
+            Connection conn = Database.getConnection();
+            Statement st = conn.createStatement();
+            ResultSet rs = st.executeQuery("SELECT * FROM inventory");
+            while (rs.next()) {
+                list.add(new Item(rs.getInt("id"), rs.getString("item"), rs.getInt("quantity"), rs.getInt("threshold")));
+            }
+            rs.close();
+            st.close();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return list;
+    }
+
+    public static void addItem(String name, int qty, int threshold) {
+        try {
+            Connection conn = Database.getConnection();
+            PreparedStatement ps = conn.prepareStatement("INSERT INTO inventory(item,quantity,threshold) VALUES(?,?,?)");
+            ps.setString(1, name);
+            ps.setInt(2, qty);
+            ps.setInt(3, threshold);
+            ps.executeUpdate();
+            ps.close();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void updateQuantity(int id, int qty) {
+        try {
+            Connection conn = Database.getConnection();
+            PreparedStatement ps = conn.prepareStatement("UPDATE inventory SET quantity=? WHERE id=?");
+            ps.setInt(1, qty);
+            ps.setInt(2, id);
+            ps.executeUpdate();
+            ps.close();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/db/MedicationDAO.java
+++ b/src/db/MedicationDAO.java
@@ -1,0 +1,38 @@
+package db;
+
+import java.sql.*;
+
+public class MedicationDAO {
+    public static void record(int studentId, String medicine, String dosage) {
+        try {
+            Connection conn = Database.getConnection();
+            PreparedStatement ps = conn.prepareStatement(
+                "INSERT INTO medications(student_id, medicine, dosage, time_given) VALUES(?,?,?,datetime('now'))");
+            ps.setInt(1, studentId);
+            ps.setString(2, medicine);
+            ps.setString(3, dosage);
+            ps.executeUpdate();
+            ps.close();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static boolean hasReceivedToday(int studentId, String medicine) {
+        try {
+            Connection conn = Database.getConnection();
+            PreparedStatement ps = conn.prepareStatement(
+                "SELECT COUNT(*) FROM medications WHERE student_id=? AND medicine=? AND date(time_given)=date('now')");
+            ps.setInt(1, studentId);
+            ps.setString(2, medicine);
+            ResultSet rs = ps.executeQuery();
+            boolean exists = rs.next() && rs.getInt(1) > 0;
+            rs.close();
+            ps.close();
+            return exists;
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+}

--- a/src/db/StudentDAO.java
+++ b/src/db/StudentDAO.java
@@ -1,0 +1,48 @@
+package db;
+
+import model.Student;
+import java.sql.*;
+
+public class StudentDAO {
+    public static Student findById(int id) {
+        try {
+            Connection conn = Database.getConnection();
+            PreparedStatement ps = conn.prepareStatement("SELECT * FROM students WHERE id = ?");
+            ps.setInt(1, id);
+            ResultSet rs = ps.executeQuery();
+            if (rs.next()) {
+                return mapStudent(rs);
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    public static Student findByName(String name) {
+        try {
+            Connection conn = Database.getConnection();
+            PreparedStatement ps = conn.prepareStatement("SELECT * FROM students WHERE name LIKE ? LIMIT 1");
+            ps.setString(1, name);
+            ResultSet rs = ps.executeQuery();
+            if (rs.next()) {
+                return mapStudent(rs);
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    private static Student mapStudent(ResultSet rs) throws SQLException {
+        return new Student(
+            rs.getInt("id"),
+            rs.getString("name"),
+            rs.getString("class"),
+            rs.getString("photo"),
+            rs.getString("conditions"),
+            rs.getString("allergies"),
+            rs.getString("emergency_contact")
+        );
+    }
+}

--- a/src/model/Student.java
+++ b/src/model/Student.java
@@ -1,0 +1,29 @@
+package model;
+
+public class Student {
+    private int id;
+    private String name;
+    private String studentClass;
+    private String photo;
+    private String conditions;
+    private String allergies;
+    private String emergencyContact;
+
+    public Student(int id, String name, String studentClass, String photo, String conditions, String allergies, String emergencyContact) {
+        this.id = id;
+        this.name = name;
+        this.studentClass = studentClass;
+        this.photo = photo;
+        this.conditions = conditions;
+        this.allergies = allergies;
+        this.emergencyContact = emergencyContact;
+    }
+
+    public int getId() { return id; }
+    public String getName() { return name; }
+    public String getStudentClass() { return studentClass; }
+    public String getPhoto() { return photo; }
+    public String getConditions() { return conditions; }
+    public String getAllergies() { return allergies; }
+    public String getEmergencyContact() { return emergencyContact; }
+}

--- a/src/model/User.java
+++ b/src/model/User.java
@@ -1,0 +1,25 @@
+package model;
+
+public class User {
+    private int id;
+    private String username;
+    private String role;
+
+    public User(int id, String username, String role) {
+        this.id = id;
+        this.username = username;
+        this.role = role;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getRole() {
+        return role;
+    }
+}

--- a/src/ui/InventoryFrame.java
+++ b/src/ui/InventoryFrame.java
@@ -1,0 +1,86 @@
+package ui;
+
+import db.InventoryDAO;
+import db.InventoryDAO.Item;
+
+import javax.swing.*;
+import javax.swing.table.DefaultTableModel;
+import java.awt.*;
+import java.util.List;
+
+public class InventoryFrame extends JFrame {
+    private DefaultTableModel model;
+    private JTable table;
+
+    public InventoryFrame() {
+        super("Inventory Management");
+        setSize(500,300);
+        setLocationRelativeTo(null);
+        initComponents();
+    }
+
+    private void initComponents() {
+        model = new DefaultTableModel(new Object[]{"Item","Quantity","Threshold"},0);
+        table = new JTable(model);
+        reload();
+        add(new JScrollPane(table), BorderLayout.CENTER);
+
+        JPanel controls = new JPanel(new GridLayout(2,4));
+        JTextField nameField = new JTextField();
+        JTextField qtyField = new JTextField();
+        JTextField thField = new JTextField();
+        JButton addBtn = new JButton("Add Item");
+        addBtn.addActionListener(e -> {
+            try {
+                InventoryDAO.addItem(nameField.getText(), Integer.parseInt(qtyField.getText()), Integer.parseInt(thField.getText()));
+                nameField.setText(""); qtyField.setText(""); thField.setText("");
+                reload();
+            } catch (NumberFormatException ex) {
+                JOptionPane.showMessageDialog(this, "Enter valid numbers");
+            }
+        });
+        controls.add(new JLabel("Name"));
+        controls.add(nameField);
+        controls.add(new JLabel("Qty"));
+        controls.add(qtyField);
+        controls.add(new JLabel("Threshold"));
+        controls.add(thField);
+        controls.add(new JLabel());
+        controls.add(addBtn);
+
+        JPanel usagePanel = new JPanel();
+        JTextField useField = new JTextField(5);
+        JButton useBtn = new JButton("Use Selected");
+        useBtn.addActionListener(e -> {
+            int row = table.getSelectedRow();
+            if (row >=0) {
+                try {
+                    List<Item> items = InventoryDAO.getAll();
+                    Item it = items.get(row);
+                    int use = Integer.parseInt(useField.getText());
+                    int newQty = Math.max(0, it.getQuantity() - use);
+                    InventoryDAO.updateQuantity(it.getId(), newQty);
+                    reload();
+                } catch (NumberFormatException ex) {
+                    JOptionPane.showMessageDialog(this, "Enter valid quantity");
+                }
+            }
+        });
+        usagePanel.add(new JLabel("Use quantity:"));
+        usagePanel.add(useField);
+        usagePanel.add(useBtn);
+
+        JPanel bottom = new JPanel(new BorderLayout());
+        bottom.add(controls, BorderLayout.NORTH);
+        bottom.add(usagePanel, BorderLayout.SOUTH);
+        add(bottom, BorderLayout.SOUTH);
+    }
+
+    private void reload() {
+        model.setRowCount(0);
+        List<Item> items = InventoryDAO.getAll();
+        for (Item i : items) {
+            model.addRow(new Object[]{i.getName(), i.getQuantity(), i.getThreshold()});
+        }
+    }
+}

--- a/src/ui/LoginFrame.java
+++ b/src/ui/LoginFrame.java
@@ -1,0 +1,53 @@
+package ui;
+
+import db.AuthService;
+import model.User;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.*;
+
+public class LoginFrame extends JFrame {
+    private JTextField usernameField;
+    private JPasswordField passwordField;
+
+    public LoginFrame() {
+        super("School Clinic Login");
+        setDefaultCloseOperation(EXIT_ON_CLOSE);
+        setSize(350, 200);
+        setLocationRelativeTo(null);
+        initComponents();
+    }
+
+    private void initComponents() {
+        JPanel panel = new JPanel(new GridLayout(3,2));
+        panel.add(new JLabel("Username:"));
+        usernameField = new JTextField();
+        panel.add(usernameField);
+        panel.add(new JLabel("Password:"));
+        passwordField = new JPasswordField();
+        panel.add(passwordField);
+        JButton loginBtn = new JButton("Login");
+        loginBtn.addActionListener(e -> handleLogin());
+        panel.add(new JLabel());
+        panel.add(loginBtn);
+        add(panel);
+    }
+
+    private void handleLogin() {
+        String user = usernameField.getText();
+        String pass = new String(passwordField.getPassword());
+        User u = AuthService.authenticate(user, pass);
+        if (u != null) {
+            JOptionPane.showMessageDialog(this, "Welcome " + u.getUsername());
+            dispose();
+            if ("nurse".equals(u.getRole())) {
+                new NurseDashboard(u).setVisible(true);
+            } else {
+                new TeacherSlipForm(u).setVisible(true);
+            }
+        } else {
+            JOptionPane.showMessageDialog(this, "Invalid credentials");
+        }
+    }
+}

--- a/src/ui/MedicationForm.java
+++ b/src/ui/MedicationForm.java
@@ -1,0 +1,48 @@
+package ui;
+
+import db.MedicationDAO;
+
+import javax.swing.*;
+import java.awt.*;
+
+public class MedicationForm extends JFrame {
+    public MedicationForm() {
+        super("Record Medication");
+        setSize(350,200);
+        setLocationRelativeTo(null);
+        initComponents();
+    }
+
+    private void initComponents() {
+        JPanel panel = new JPanel(new GridLayout(4,2));
+        JTextField studentField = new JTextField();
+        JTextField medField = new JTextField();
+        JTextField doseField = new JTextField();
+        panel.add(new JLabel("Student ID:"));
+        panel.add(studentField);
+        panel.add(new JLabel("Medicine:"));
+        panel.add(medField);
+        panel.add(new JLabel("Dosage:"));
+        panel.add(doseField);
+        JButton submit = new JButton("Record");
+        submit.addActionListener(e -> {
+            try {
+                int sid = Integer.parseInt(studentField.getText());
+                String med = medField.getText();
+                String dose = doseField.getText();
+                if (MedicationDAO.hasReceivedToday(sid, med)) {
+                    JOptionPane.showMessageDialog(this, "Medicine already given today!");
+                } else {
+                    MedicationDAO.record(sid, med, dose);
+                    JOptionPane.showMessageDialog(this, "Recorded");
+                    dispose();
+                }
+            } catch (NumberFormatException ex) {
+                JOptionPane.showMessageDialog(this, "Invalid student ID");
+            }
+        });
+        panel.add(new JLabel());
+        panel.add(submit);
+        add(panel);
+    }
+}

--- a/src/ui/NurseDashboard.java
+++ b/src/ui/NurseDashboard.java
@@ -1,0 +1,83 @@
+package ui;
+
+import db.StudentDAO;
+import db.InventoryDAO;
+import db.InventoryDAO.Item;
+import model.Student;
+import model.User;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.List;
+
+public class NurseDashboard extends JFrame {
+    private User nurse;
+    private JTextField searchField;
+    private JTextArea infoArea;
+
+    public NurseDashboard(User nurse) {
+        super("Nurse Dashboard");
+        this.nurse = nurse;
+        setSize(500,400);
+        setLocationRelativeTo(null);
+        setDefaultCloseOperation(EXIT_ON_CLOSE);
+        initComponents();
+        checkLowStock();
+    }
+
+    private void initComponents() {
+        JPanel top = new JPanel();
+        searchField = new JTextField(20);
+        JButton searchBtn = new JButton("Search Student");
+        searchBtn.addActionListener(e -> searchStudent());
+        top.add(searchField);
+        top.add(searchBtn);
+        infoArea = new JTextArea();
+        infoArea.setEditable(false);
+        add(top, BorderLayout.NORTH);
+        add(new JScrollPane(infoArea), BorderLayout.CENTER);
+
+        JPanel bottom = new JPanel();
+        JButton inventoryBtn = new JButton("Inventory");
+        inventoryBtn.addActionListener(e -> new InventoryFrame().setVisible(true));
+        JButton medBtn = new JButton("Record Medication");
+        medBtn.addActionListener(e -> new MedicationForm().setVisible(true));
+        bottom.add(inventoryBtn);
+        bottom.add(medBtn);
+        add(bottom, BorderLayout.SOUTH);
+    }
+
+    private void searchStudent() {
+        String term = searchField.getText();
+        Student s = null;
+        try {
+            int id = Integer.parseInt(term);
+            s = StudentDAO.findById(id);
+        } catch (NumberFormatException ex) {
+            s = StudentDAO.findByName(term);
+        }
+        if (s != null) {
+            infoArea.setText("ID: " + s.getId() + "\n" +
+                "Name: " + s.getName() + "\n" +
+                "Class: " + s.getStudentClass() + "\n" +
+                "Conditions: " + s.getConditions() + "\n" +
+                "Allergies: " + s.getAllergies() + "\n" +
+                "Emergency Contact: " + s.getEmergencyContact());
+        } else {
+            infoArea.setText("Student not found");
+        }
+    }
+
+    private void checkLowStock() {
+        List<Item> items = InventoryDAO.getAll();
+        StringBuilder alerts = new StringBuilder();
+        for (Item i : items) {
+            if (i.getQuantity() <= i.getThreshold()) {
+                alerts.append(i.getName()).append(" low (" + i.getQuantity() + ")\n");
+            }
+        }
+        if (alerts.length() > 0) {
+            JOptionPane.showMessageDialog(this, alerts.toString(), "Low Stock Alerts", JOptionPane.WARNING_MESSAGE);
+        }
+    }
+}

--- a/src/ui/TeacherSlipForm.java
+++ b/src/ui/TeacherSlipForm.java
@@ -1,0 +1,69 @@
+package ui;
+
+import db.Database;
+import model.User;
+
+import javax.swing.*;
+import java.awt.*;
+import java.sql.*;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class TeacherSlipForm extends JFrame {
+    private User teacher;
+    private JTextField studentIdField;
+    private JTextField studentNameField;
+    private JTextField classField;
+    private JTextArea complaintArea;
+
+    public TeacherSlipForm(User teacher) {
+        super("Digital Nurse Slip");
+        this.teacher = teacher;
+        setSize(400,400);
+        setLocationRelativeTo(null);
+        setDefaultCloseOperation(EXIT_ON_CLOSE);
+        initComponents();
+    }
+
+    private void initComponents() {
+        JPanel panel = new JPanel(new GridLayout(5,2));
+        panel.add(new JLabel("Student ID:"));
+        studentIdField = new JTextField();
+        panel.add(studentIdField);
+        panel.add(new JLabel("Student Name:"));
+        studentNameField = new JTextField();
+        panel.add(studentNameField);
+        panel.add(new JLabel("Class:"));
+        classField = new JTextField();
+        panel.add(classField);
+        panel.add(new JLabel("Complaint:"));
+        complaintArea = new JTextArea(3,20);
+        panel.add(new JScrollPane(complaintArea));
+        JButton submitBtn = new JButton("Send to Nurse");
+        submitBtn.addActionListener(e -> submitSlip());
+        add(panel, BorderLayout.CENTER);
+        add(submitBtn, BorderLayout.SOUTH);
+    }
+
+    private void submitSlip() {
+        try {
+            Connection conn = Database.getConnection();
+            PreparedStatement ps = conn.prepareStatement("INSERT INTO slips(student_id, teacher_name, complaint, time_sent, status) VALUES(?,?,?,?,?)");
+            ps.setString(1, studentIdField.getText());
+            ps.setString(2, teacher.getUsername());
+            ps.setString(3, complaintArea.getText());
+            ps.setString(4, LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")));
+            ps.setString(5, "pending");
+            ps.executeUpdate();
+            ps.close();
+            JOptionPane.showMessageDialog(this, "Slip sent to nurse");
+            studentIdField.setText("");
+            studentNameField.setText("");
+            classField.setText("");
+            complaintArea.setText("");
+        } catch (Exception e) {
+            e.printStackTrace();
+            JOptionPane.showMessageDialog(this, "Error sending slip");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- remove the unused `data/sample-data.sql` to avoid binary file warnings and rely on programmatic seeding instead
- ensure the SQLite connection creates the `data` directory if it doesn't exist
- update documentation to note that the database seeds itself with sample records

## Testing
- `curl -L -o sqlite-jdbc.jar https://repo1.maven.org/maven2/org/xerial/sqlite-jdbc/3.44.1.0/sqlite-jdbc-3.44.1.0.jar`
- `javac -cp sqlite-jdbc.jar -d bin $(find src -name '*.java')`
- `timeout 5s java -cp bin:sqlite-jdbc.jar -Djava.awt.headless=true Main` *(fails: HeadlessException)*

------
https://chatgpt.com/codex/tasks/task_e_68adf565bcd88333982b0dadc81ed5bd